### PR TITLE
Fix preview not showing if multi isn't ISurvivalConstructable

### DIFF
--- a/src/main/java/blockrenderer6343/api/utils/PositionedIStructureElement.java
+++ b/src/main/java/blockrenderer6343/api/utils/PositionedIStructureElement.java
@@ -1,6 +1,6 @@
 package blockrenderer6343.api.utils;
 
-import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
+import com.gtnewhorizon.structurelib.alignment.constructable.IConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureElement;
 
 public class PositionedIStructureElement {
@@ -8,9 +8,9 @@ public class PositionedIStructureElement {
     public final int x;
     public final int y;
     public final int z;
-    public final IStructureElement<ISurvivalConstructable> element;
+    public final IStructureElement<IConstructable> element;
 
-    public PositionedIStructureElement(int x, int y, int z, IStructureElement<ISurvivalConstructable> element) {
+    public PositionedIStructureElement(int x, int y, int z, IStructureElement<IConstructable> element) {
         this.x = x;
         this.y = y;
         this.z = z;

--- a/src/main/java/blockrenderer6343/integration/gregtech/GT_GUI_MultiblocksHandler.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GT_GUI_MultiblocksHandler.java
@@ -45,7 +45,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.ITurnable;
 import gregtech.api.threads.GT_Runnable_MachineBlockUpdate;
 
-public class GT_GUI_MultiblocksHandler extends GUI_MultiblocksHandler<ISurvivalConstructable> {
+public class GT_GUI_MultiblocksHandler extends GUI_MultiblocksHandler<IConstructable> {
 
     protected static final int TIER_BUTTON_X = LAYER_BUTTON_X + 5;
     protected static final int TIER_BUTTON_Y = LAYER_BUTTON_Y - ICON_SIZE_Y;
@@ -300,6 +300,6 @@ public class GT_GUI_MultiblocksHandler extends GUI_MultiblocksHandler<ISurvivalC
                         event.getX(),
                         event.getY(),
                         event.getZ(),
-                        (IStructureElement<ISurvivalConstructable>) event.getElement()));
+                        (IStructureElement<IConstructable>) event.getElement()));
     }
 }

--- a/src/main/java/blockrenderer6343/integration/nei/GT_NEI_MultiblocksHandler.java
+++ b/src/main/java/blockrenderer6343/integration/nei/GT_NEI_MultiblocksHandler.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
+import com.gtnewhorizon.structurelib.alignment.constructable.IConstructable;
 
 import blockrenderer6343.ClientProxy;
 import blockrenderer6343.integration.gregtech.GT_GUI_MultiblocksHandler;
@@ -30,7 +30,7 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 
 public class GT_NEI_MultiblocksHandler extends TemplateRecipeHandler {
 
-    public static List<ISurvivalConstructable> multiblocksList = new ArrayList<>();
+    public static List<IConstructable> multiblocksList = new ArrayList<>();
     private static final GT_GUI_MultiblocksHandler baseHandler = ClientProxy.guiMultiblocksHandler;
 
     public static final int CANDIDATE_SLOTS_X = 150;
@@ -46,8 +46,8 @@ public class GT_NEI_MultiblocksHandler extends TemplateRecipeHandler {
     public GT_NEI_MultiblocksHandler() {
         super();
         for (IMetaTileEntity mte : METATILEENTITIES) {
-            if (mte instanceof ISurvivalConstructable) {
-                multiblocksList.add((ISurvivalConstructable) mte);
+            if (mte instanceof IConstructable) {
+                multiblocksList.add((IConstructable) mte);
             }
         }
     }
@@ -136,7 +136,7 @@ public class GT_NEI_MultiblocksHandler extends TemplateRecipeHandler {
     }
 
     private void tryLoadMultiblocks(ItemStack candidate) {
-        for (ISurvivalConstructable multiblock : multiblocksList) {
+        for (IConstructable multiblock : multiblocksList) {
             ItemStack stackForm = ((IMetaTileEntity) multiblock).getStackForm(1);
             if (NEIClientUtils.areStacksSameType(stackForm, candidate)) {
                 baseHandler.setOnIngredientChanged(ingredients -> {


### PR DESCRIPTION
https://github.com/GTNewHorizons/BlockRenderer6343/pull/7 essentially limited the preview to only multis that implement ISurvivalConstructable which ends up excluding a few. This changes it to IConstructable which most (all?) multis implement.

I haven't tested every multi mentioned in the ticket but the ones that I have showed correctly, and the bricked blast furnace preview still works. Nothing should change in regards to the multis that had a functioning preview before.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15110