### PR TITLE
Fix crash when switching tier after projecting a multiblock

### DIFF
--- a/src/main/java/blockrenderer6343/integration/gregtech/GT_GUI_MultiblocksHandler.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GT_GUI_MultiblocksHandler.java
@@ -111,7 +111,7 @@ public class GT_GUI_MultiblocksHandler extends GUI_MultiblocksHandler<IConstruct
         MovingObjectPosition lookingPos = player.rayTrace(10, 1);
         if (lookingPos.typeOfHit == MovingObjectPosition.MovingObjectType.MISS) return;
         int playerDir = MathHelper.floor_double((player.rotationYaw * 4F) / 360F + 0.5D) & 3;
-        ItemStack itemStack = stackForm;
+        ItemStack itemStack = stackForm.copy();
         if (!baseWorld.isAirBlock(lookingPos.blockX, lookingPos.blockY + 1, lookingPos.blockZ)) return;
         itemStack.getItem().onItemUse(
                 itemStack,


### PR DESCRIPTION
stackForm's stacksize was getting set to 0 when projecting a multi thus causing the NPE, taking a copy of the stack fixes that.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15185