### PR TITLE
Add localization and ability to change UI colors

### DIFF
--- a/src/main/java/blockrenderer6343/client/utils/GuiText.java
+++ b/src/main/java/blockrenderer6343/client/utils/GuiText.java
@@ -1,0 +1,52 @@
+package blockrenderer6343.client.utils;
+
+import net.minecraft.util.StatCollector;
+
+import blockrenderer6343.BlockRenderer6343;
+
+public enum GuiText {
+
+    // UI Text
+    Tier,
+    Layer,
+    // UI Colors
+    FontColor(0x333333),
+    BgColor(0xC6C6C6),
+    ButtonEnabledColor(0x202020),
+    ButtonDisabledColor(0xA0A0A0),
+    ButtonHoveredColor(0xFFFFA0);
+
+    private final String root;
+    private final int color;
+
+    GuiText() {
+        this.root = "gui.blockrenderer6343";
+        this.color = 0x000000;
+    }
+
+    GuiText(final int hex) {
+        this.root = "gui.blockrenderer6343";
+        this.color = hex;
+    }
+
+    public int getColor() {
+        String hex = StatCollector.translateToLocal(this.getUnlocalized());
+        int color = this.color;
+        if (hex.length() <= 6) {
+            try {
+                color = Integer.parseUnsignedInt(hex, 16);
+            } catch (final NumberFormatException e) {
+                BlockRenderer6343.warn("Couldn't format color correctly for: " + this.root + " -> " + hex);
+            }
+        }
+        return color;
+    }
+
+    public String getLocal() {
+        return StatCollector.translateToLocal(this.getUnlocalized());
+    }
+
+    public String getUnlocalized() {
+        return this.root + '.' + this.toString();
+    }
+}

--- a/src/main/java/blockrenderer6343/integration/gregtech/GT_GUI_MultiblocksHandler.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GT_GUI_MultiblocksHandler.java
@@ -36,6 +36,7 @@ import blockrenderer6343.BlockRenderer6343;
 import blockrenderer6343.api.utils.BlockPosition;
 import blockrenderer6343.api.utils.CreativeItemSource;
 import blockrenderer6343.api.utils.PositionedIStructureElement;
+import blockrenderer6343.client.utils.GuiText;
 import blockrenderer6343.client.world.ClientFakePlayer;
 import blockrenderer6343.common.GUI_MultiblocksHandler;
 import codechicken.lib.math.MathHelper;
@@ -47,15 +48,19 @@ import gregtech.api.threads.GT_Runnable_MachineBlockUpdate;
 
 public class GT_GUI_MultiblocksHandler extends GUI_MultiblocksHandler<IConstructable> {
 
-    protected static final int TIER_BUTTON_X = LAYER_BUTTON_X + 5;
+    protected static final int TIER_BUTTON_X = LAYER_BUTTON_X;
     protected static final int TIER_BUTTON_Y = LAYER_BUTTON_Y - ICON_SIZE_Y;
-    protected static final int TIER_BUTTON_SPACE_X = 25;
     protected static final int PROJECT_BUTTON_X = 145;
     protected static final int PROJECT_BUTTON_Y = -5;
     private static final BlockPosition MB_PLACE_POS = new BlockPosition(0, 64, 0);
     public static final int MAX_PLACE_ROUNDS = 2000;
 
     protected static int tierIndex = 1;
+
+    protected static String guiTextTier;
+    protected static String guiTierButtonTitle;
+    protected static int initialTierButtonTitleWidth;
+    protected ClearGuiButton previousTierButton, nextTierButton;
 
     private static EntityPlayer fakeMultiblockBuilder;
 
@@ -66,16 +71,10 @@ public class GT_GUI_MultiblocksHandler extends GUI_MultiblocksHandler<IConstruct
     public GT_GUI_MultiblocksHandler() {
         super();
 
-        ClearGuiButton previousTierButton = new ClearGuiButton(
+        previousTierButton = new ClearGuiButton(0, TIER_BUTTON_X, TIER_BUTTON_Y, ICON_SIZE_X, ICON_SIZE_Y, "<");
+        nextTierButton = new ClearGuiButton(
                 0,
-                TIER_BUTTON_X,
-                TIER_BUTTON_Y,
-                ICON_SIZE_X,
-                ICON_SIZE_Y,
-                "<");
-        ClearGuiButton nextTierButton = new ClearGuiButton(
-                0,
-                TIER_BUTTON_X + ICON_SIZE_X + TIER_BUTTON_SPACE_X,
+                TIER_BUTTON_X + ICON_SIZE_X,
                 TIER_BUTTON_Y,
                 ICON_SIZE_X,
                 ICON_SIZE_Y,
@@ -91,6 +90,22 @@ public class GT_GUI_MultiblocksHandler extends GUI_MultiblocksHandler<IConstruct
         buttons.put(previousTierButton, this::togglePreviousTier);
         buttons.put(nextTierButton, this::toggleNextTier);
         buttons.put(projectMultiblocksButton, this::projectMultiblocks);
+    }
+
+    @Override
+    protected void setLocalizationAndColor() {
+        super.setLocalizationAndColor();
+        guiTextTier = GuiText.Tier.getLocal();
+        previousTierButton.setColors(super.buttonColorEnabled, super.buttonColorDisabled, super.buttonColorHovered);
+        nextTierButton.setColors(super.buttonColorEnabled, super.buttonColorDisabled, super.buttonColorHovered);
+
+        guiTierButtonTitle = getTierButtonTitle();
+
+        FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
+        initialTierButtonTitleWidth = fontRenderer.getStringWidth(guiTierButtonTitle);
+        nextTierButton.xPosition = TIER_BUTTON_X + ICON_SIZE_X
+                + initialTierButtonTitleWidth
+                - fontRenderer.getStringWidth("<") / 2;
     }
 
     public void setOnCandidateChanged(Consumer<List<List<ItemStack>>> callback) {
@@ -143,12 +158,14 @@ public class GT_GUI_MultiblocksHandler extends GUI_MultiblocksHandler<IConstruct
 
     private void toggleNextTier() {
         tierIndex++;
+        guiTierButtonTitle = getTierButtonTitle();
         initializeSceneRenderer(false);
     }
 
     private void togglePreviousTier() {
         if (tierIndex > 1) {
             tierIndex--;
+            guiTierButtonTitle = getTierButtonTitle();
             initializeSceneRenderer(false);
         }
     }
@@ -158,17 +175,21 @@ public class GT_GUI_MultiblocksHandler extends GUI_MultiblocksHandler<IConstruct
         return I18n.format(stackForm.getDisplayName());
     }
 
+    protected String getTierButtonTitle() {
+        return guiTextTier + ": " + tierIndex;
+    }
+
     @Override
     protected void drawButtonsTitle() {
         super.drawButtonsTitle();
 
         FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
-        String tierText = "Tier: " + tierIndex;
         fontRenderer.drawString(
-                tierText,
-                TIER_BUTTON_X + ICON_SIZE_X + (TIER_BUTTON_SPACE_X - fontRenderer.getStringWidth(tierText)) / 2,
-                TIER_BUTTON_Y + 5,
-                0x333333);
+                guiTierButtonTitle,
+                TIER_BUTTON_X + ICON_SIZE_X
+                        + (initialTierButtonTitleWidth - fontRenderer.getStringWidth(guiTierButtonTitle)) / 2,
+                TIER_BUTTON_Y + 2,
+                super.guiColorFont);
     }
 
     @Override

--- a/src/main/resources/assets/blockrenderer6343/lang/en_US.lang
+++ b/src/main/resources/assets/blockrenderer6343/lang/en_US.lang
@@ -1,0 +1,7 @@
+gui.blockrenderer6343.Tier=Tier
+gui.blockrenderer6343.Layer=Layer
+gui.blockrenderer6343.FontColor=333333
+gui.blockrenderer6343.BgColor=C6C6C6
+gui.blockrenderer6343.ButtonHoveredColor=FFFFA0
+gui.blockrenderer6343.ButtonEnabledColor=202020
+gui.blockrenderer6343.ButtonDisabledColor=A0A0A0


### PR DESCRIPTION
This PR adds the following:
- UI text translation using `.lang` files
- Changeable UI-text color and background color by specifying 6-digit hex-colors in the `.lang` file  

In order to accomplish this, the enum `GuiText.java` is added. It contains default and fallback values as well as getter for localization and colors. Once upon a multiblock load, the `.lang` file gets accessed through `setLocalizationAndColor()` and the needed values are read.

The position of `nextLayer` and `nextTier` buttons is now dynamic and depends on `FontRenderer.StringWidth( <buttonTitle> )` in order to make any text fit. It's ensured, that higher tier or layer counts won't move the buttons by saving the initial string width and using that to specify button positions for the render.