### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/java/blockrenderer6343/BlockRenderer6343.java
+++ b/src/main/java/blockrenderer6343/BlockRenderer6343.java
@@ -19,8 +19,7 @@ import cpw.mods.fml.relauncher.Side;
         version = Tags.VERSION,
         name = BlockRenderer6343.MOD_NAME,
         acceptedMinecraftVersions = "[1.7.10]",
-        dependencies = " required-after:CodeChickenLib;" + " required-after:NotEnoughItems;"
-                + "required-after:structurelib")
+        dependencies = "required-after:NotEnoughItems;required-after:structurelib")
 public class BlockRenderer6343 {
 
     public static final String MOD_ID = "blockrenderer6343";

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -12,10 +12,6 @@
 		"credits": "",
 		"logoFile": "",
 		"screenshots": [],
-		"parent": "",
-		"requiredMods": [],
-		"dependencies": [],
-		"dependants": [],
-		"useDependencyInformation": true
+		"parent": ""
 	}]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.