### PR TITLE
Fix some multiblock placements aborting too early

### DIFF
--- a/src/main/java/blockrenderer6343/client/world/TrackedDummyWorld.java
+++ b/src/main/java/blockrenderer6343/client/world/TrackedDummyWorld.java
@@ -28,6 +28,7 @@ public class TrackedDummyWorld extends DummyWorld {
     private final Vector3f minPos = new Vector3f(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE);
     private final Vector3f maxPos = new Vector3f(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE);
     private final Vector3f size = new Vector3f();
+    private boolean hasChanged;
 
     @Override
     public boolean setBlock(int x, int y, int z, Block block, int meta, int flags) {
@@ -50,6 +51,7 @@ public class TrackedDummyWorld extends DummyWorld {
             block.onBlockAdded(this, x, y, z);
         }
 
+        hasChanged = true;
         minPos.x = Math.min(minPos.x, x);
         minPos.y = Math.min(minPos.y, y);
         minPos.z = Math.min(minPos.z, z);
@@ -311,5 +313,11 @@ public class TrackedDummyWorld extends DummyWorld {
 
     private boolean isBlockTargeted(MovingObjectPosition result, LongSet targetedBlocks) {
         return targetedBlocks.contains(CoordinatePacker.pack(result.blockX, result.blockY, result.blockZ));
+    }
+
+    public boolean hasChanged() {
+        boolean changed = hasChanged;
+        hasChanged = false;
+        return changed;
     }
 }

--- a/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
@@ -174,14 +174,14 @@ public class GTGuiMultiblockHandler extends GuiMultiblockHandler {
         IMetaTileEntity mte = ((IGregTechTileEntity) tTileEntity).getMetaTileEntity();
 
         if (mte instanceof ISurvivalConstructable survivalConstructable) {
-            int result, iterations = 0;
+            int iterations = 0;
             do {
-                result = survivalConstructable.survivalConstruct(
+                survivalConstructable.survivalConstruct(
                         getBuildTriggerStack(),
                         Integer.MAX_VALUE,
                         ISurvivalBuildEnvironment.create(CreativeItemSource.instance, FAKE_PLAYER));
                 iterations++;
-            } while (result > 0 && iterations < MAX_PLACE_ROUNDS);
+            } while (renderer.world.hasChanged() && iterations < MAX_PLACE_ROUNDS);
         } else if (tTileEntity instanceof IConstructableProvider iConstructableProvider) {
             constructable = iConstructableProvider.getConstructable();
         } else if (tTileEntity instanceof IConstructable iConstructable) {

--- a/src/main/java/blockrenderer6343/integration/structurelib/StructureCompatGuiHandler.java
+++ b/src/main/java/blockrenderer6343/integration/structurelib/StructureCompatGuiHandler.java
@@ -38,7 +38,7 @@ public class StructureCompatGuiHandler extends GuiMultiblockHandler {
                 tryConstruct = true;
                 break;
             }
-        } while (result > 0 && iterations < MAX_PLACE_ROUNDS);
+        } while (renderer.world.hasChanged() && iterations < MAX_PLACE_ROUNDS);
 
         if (tryConstruct) {
             multi.construct(getBuildTriggerStack(), false);


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18510

This problem arises when the multiple `survivialBuildPiece()` are `+=` in `survivalConstruct()` since returning anything below 0 would previously cause the preview construction to abort.

A possible example for the YottTank with some edits to illustrate the point

```
    public int survivalConstruct(ItemStack stackSize, int elementBudget, ISurvivalBuildEnvironment env) {
        if (mMachine) return -1;
        int built = 0;
		// This piece is finished which causes built to be -1 
        built += survivialBuildPiece(YOTTANK_BOTTOM, stackSize, 2, 0, 0, elementBudget, env, false, true); 
        int height = 15;
		
		// This piece is also finished meaning built is now -2
        built += survivialBuildPiece(YOTTANK_TOP, stackSize, 2, height + 2, 0, elementBudget - built, env, false, true);

		// 14 of these were already finished and 
		// The last piece only placed a hatch in this round (which are always placed individually)
		// The return value ends up being -15 in this case
        while (height > 0) {
            built += survivialBuildPiece(YOTTANK_MID, stackSize, 2, height, 0, elementBudget - built, env, false, true);
            height--;
        }

		// returns -15 which causes the construction to abort despite not being finished.
        return built;
    }
```

Previously we fixed that by adding `if (built > 0) return built;` after most `survivialBuildPiece()` but that's kinda annoying and unnecessary, especially since we can check whether something was actually placed in the world to more reliably determine whether construction should stop.
