### PR TITLE
Add support for Botania Multiblocks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,7 @@
 // Add your dependencies here
 
 dependencies {
+    api("com.github.GTNewHorizons:Postea:1.1.2") //doesn't compile without it for some reason
     api('com.github.GTNewHorizons:StructureLib:1.4.10:dev')
     api('com.github.GTNewHorizons:GTNHLib:0.6.24:dev')
     implementation("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.309:dev")

--- a/gradle.properties
+++ b/gradle.properties
@@ -142,7 +142,7 @@ modrinthProjectId =
 #       type can be one of [project, version],
 #       and the name is the Modrinth project or version slug/id of the other mod.
 # Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
-# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+# Note: UniMixins is automatically set as a required dependency if usesMixins = true.
 modrinthRelations =
 
 # Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.38'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.41'
 }
 
 

--- a/src/main/java/blockrenderer6343/client/utils/BRUtil.java
+++ b/src/main/java/blockrenderer6343/client/utils/BRUtil.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
@@ -157,18 +157,20 @@ public class GTGuiMultiblockHandler extends GuiMultiblockHandler {
         }
 
         IConstructable constructable = null;
-        ItemStack copy = stackForm.copy();
-        copy.getItem().onItemUse(
-                copy,
-                FAKE_PLAYER,
-                renderer.world,
-                MB_PLACE_POS.x,
-                MB_PLACE_POS.y,
-                MB_PLACE_POS.z,
-                0,
-                MB_PLACE_POS.x,
-                MB_PLACE_POS.y,
-                MB_PLACE_POS.z);
+        if (stackForm.getItem() != null) {
+            ItemStack copy = stackForm.copy();
+            copy.getItem().onItemUse(
+                    copy,
+                    FAKE_PLAYER,
+                    renderer.world,
+                    MB_PLACE_POS.x,
+                    MB_PLACE_POS.y,
+                    MB_PLACE_POS.z,
+                    0,
+                    MB_PLACE_POS.x,
+                    MB_PLACE_POS.y,
+                    MB_PLACE_POS.z);
+        }
 
         TileEntity tTileEntity = renderer.world.getTileEntity(MB_PLACE_POS.x, MB_PLACE_POS.y, MB_PLACE_POS.z);
         ((ITurnable) tTileEntity).setFrontFacing(ForgeDirection.SOUTH);

--- a/src/main/java/blockrenderer6343/integration/nei/faceless/FacelessMultiblocks.java
+++ b/src/main/java/blockrenderer6343/integration/nei/faceless/FacelessMultiblocks.java
@@ -1,0 +1,84 @@
+package blockrenderer6343.integration.nei.faceless;
+
+import java.util.Map;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.StatCollector;
+
+import blockrenderer6343.client.utils.BRUtil;
+import blockrenderer6343.integration.structurelib.StructureCompatNEIHandler;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+
+/**
+ * Handler for Multiblocks with no controller/TileEntity.
+ */
+public class FacelessMultiblocks {
+
+    public static ItemStack registerFacelessMultiblock(String tileEntityClass,
+            Int2ObjectMap<String> facelessMultiblocks) {
+        ItemStack stack = new ItemStack(Blocks.air, 1, 0);
+        facelessMultiblocks.put(stack.hashCode(), tileEntityClass);
+        return stack;
+    }
+
+    public static TileEntity getFromItemStack(ItemStack stack) {
+        Int2ObjectMap<String> facelessMultiblocks = StructureCompatNEIHandler.getFacelessMultiblocks();
+        String teClassName = facelessMultiblocks.get(stack.hashCode());
+
+        return BRUtil.getUnsafeTile(teClassName);
+    }
+
+    public static String getDisplayName(ItemStack stack) {
+        Int2ObjectMap<String> facelessMultiblocks = StructureCompatNEIHandler.getFacelessMultiblocks();
+        String className = facelessMultiblocks.get(stack.hashCode());
+        Class<?> tileClass;
+        try {
+            tileClass = Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+        String tileName = getTileNameFromRegistry(tileClass);
+        if (tileName != null) return tileName;
+        // In case this fails: Get the display name from the class's name
+        String simpleName = tileClass.getSimpleName();
+        tileName = convertClassNameToDisplayName(simpleName);
+        return tileName;
+    }
+
+    /**
+     * Since not every Faceless Multiblock has implemented TileEntity.getBlockType(),
+     * I have to get the display name from GameRegistry.classToNameMap
+     */
+    private static String getTileNameFromRegistry(Class<?> tileClass) {
+        try {
+            Map<?, ?> classToName = BRUtil.getClassToNameMap();
+
+            String unlocalizedName = "tile." + classToName.get(tileClass) + ".name";
+
+            return StatCollector.translateToLocal(unlocalizedName);
+        } catch (Throwable t) {
+            t.printStackTrace();
+            return null;
+        }
+    }
+
+    private static String convertClassNameToDisplayName(String className) {
+        if (className.startsWith("Tile")) {
+            className = className.substring(4);
+        }
+
+        // Use regex to split camel case words
+        String[] words = className.split("(?=[A-Z])");
+
+        // Join with spaces
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < words.length; i++) {
+            if (i > 0) result.append(' ');
+            result.append(words[i]);
+        }
+
+        return result.toString();
+    }
+}

--- a/src/main/java/blockrenderer6343/integration/nei/faceless/FacelessMultiblocks.java
+++ b/src/main/java/blockrenderer6343/integration/nei/faceless/FacelessMultiblocks.java
@@ -48,8 +48,8 @@ public class FacelessMultiblocks {
     }
 
     /**
-     * Since not every Faceless Multiblock has implemented TileEntity.getBlockType(),
-     * I have to get the display name from GameRegistry.classToNameMap
+     * Since not every Faceless Multiblock has implemented TileEntity.getBlockType(), I have to get the display name
+     * from GameRegistry.classToNameMap
      */
     private static String getTileNameFromRegistry(Class<?> tileClass) {
         try {

--- a/src/main/java/blockrenderer6343/integration/structurelib/StructureCompatGuiHandler.java
+++ b/src/main/java/blockrenderer6343/integration/structurelib/StructureCompatGuiHandler.java
@@ -13,16 +13,25 @@ import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 
 import blockrenderer6343.api.utils.CreativeItemSource;
 import blockrenderer6343.integration.nei.GuiMultiblockHandler;
+import blockrenderer6343.integration.nei.faceless.FacelessMultiblocks;
 
 public class StructureCompatGuiHandler extends GuiMultiblockHandler {
 
     @Override
-    protected void placeMultiblock() {
-        Block stackBlock = ((ItemBlock) stackForm.getItem()).field_150939_a;
-        renderer.world
-                .setBlock(MB_PLACE_POS.x, MB_PLACE_POS.y, MB_PLACE_POS.z, stackBlock, stackForm.getItemDamage(), 3);
+    protected final void placeMultiblock() {
+        TileEntity tTileEntity;
+        if (this.is_faceless) {
+            // For Multiblocks without a Controller block
+            tTileEntity = FacelessMultiblocks.getFromItemStack(stackForm);
+            renderer.world.setTileEntity(MB_PLACE_POS.x, MB_PLACE_POS.y, MB_PLACE_POS.z, tTileEntity);
+        } else {
+            Block stackBlock = ((ItemBlock) stackForm.getItem()).field_150939_a;
+            renderer.world
+                    .setBlock(MB_PLACE_POS.x, MB_PLACE_POS.y, MB_PLACE_POS.z, stackBlock, stackForm.getItemDamage(), 3);
 
-        TileEntity tTileEntity = renderer.world.getTileEntity(MB_PLACE_POS.x, MB_PLACE_POS.y, MB_PLACE_POS.z);
+            tTileEntity = renderer.world.getTileEntity(MB_PLACE_POS.x, MB_PLACE_POS.y, MB_PLACE_POS.z);
+        }
+
         IMultiblockInfoContainer<TileEntity> t = IMultiblockInfoContainer.get(tTileEntity.getClass());
         ISurvivalConstructable multi = t.toConstructable(tTileEntity, ExtendedFacing.DEFAULT);
 

--- a/src/main/java/blockrenderer6343/integration/structurelib/StructureCompatNEIHandler.java
+++ b/src/main/java/blockrenderer6343/integration/structurelib/StructureCompatNEIHandler.java
@@ -10,6 +10,7 @@ import com.gtnewhorizon.structurelib.alignment.constructable.IMultiblockInfoCont
 import blockrenderer6343.client.utils.BRUtil;
 import blockrenderer6343.integration.nei.MultiblockHandler;
 import codechicken.nei.recipe.TemplateRecipeHandler;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
@@ -20,12 +21,14 @@ public class StructureCompatNEIHandler extends MultiblockHandler {
     private static final StructureCompatGuiHandler baseHandler = new StructureCompatGuiHandler();
     private static Long2ObjectMap<ObjectSet<IConstructable>> multiBlockComponents;
     private static Object2ObjectMap<IConstructable, ItemStack> stacks;
+    private static Int2ObjectMap<String> facelessMultiblocks;
 
     static {
         new Thread(
                 new MultiblockInfoContainerScan(
                         e -> multiBlockComponents = e,
                         s -> stacks = s,
+                        s -> facelessMultiblocks = s,
                         IMultiblockInfoContainer.MULTIBLOCK_MAP)).start();
     }
 
@@ -41,6 +44,10 @@ public class StructureCompatNEIHandler extends MultiblockHandler {
     @Override
     public TemplateRecipeHandler newInstance() {
         return new StructureCompatNEIHandler();
+    }
+
+    public static Int2ObjectMap<String> getFacelessMultiblocks() {
+        return facelessMultiblocks;
     }
 
     @Override

--- a/src/main/resources/assets/blockrenderer6343/lang/en_US.lang
+++ b/src/main/resources/assets/blockrenderer6343/lang/en_US.lang
@@ -13,3 +13,4 @@ blockrenderer6343.nei.hint_dot=Hint dot: %s
 blockrenderer6343.nei.valid_hatches=Valid hatches:%s
 blockrenderer6343.nei.all=All
 blockrenderer6343.nei.not_set=Not set
+blockrenderer6343.no_controller_found=Unable to find the controller of this Multiblock


### PR DESCRIPTION
Currently, every Multiblock requires a Controller Block + TileEntity to display the data correctly. Botania Multiblocks however do not follow that structure, because they don't have a dedicated Controller. So, instead of having to manually refactor every Botania Multiblock and deal with all the bugs that that comes with, I decided to add Botania Multiblock compatability without having to change the structure of the Multiblocks. This also makes it easier for me to add the vanilla Botania Multiblocks (which were not implemented yet, might do that later this week) and further Multiblocks in the future.

Another thing i wanted to mention: The projection of the multiblocks don't work. I think this is an issue with every non-GTNH multiblocks, since it also doesn't work for the RailCraft multiblocks, only for the GTNH multiblocks.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20445

<img width="700" height="875" alt="2025-07-22_20 40 51" src="https://github.com/user-attachments/assets/f0468124-03d8-4659-9517-dd9c8ad1ba20" />
