### PR TITLE
Fix preview for multiblocks with custom hatches

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,11 +1,11 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:StructureLib:1.4.23:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.7.0:dev')
-    implementation("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.156:dev")
-    implementation('com.github.GTNewHorizons:NotEnoughItems:2.8.11-GTNH:dev')
-    compileOnly("com.github.GTNewHorizons:NotEnoughEnergistics:1.7.14:dev")
+    api('com.github.GTNewHorizons:StructureLib:1.4.28:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.9.6:dev')
+    implementation("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.232:dev")
+    implementation('com.github.GTNewHorizons:NotEnoughItems:2.8.55-GTNH:dev')
+    compileOnly("com.github.GTNewHorizons:NotEnoughEnergistics:1.7.22:dev")
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:StructureCompat:0.7.4:dev")
 }

--- a/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
@@ -30,6 +30,7 @@ import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import blockrenderer6343.api.utils.CreativeItemSource;
 import blockrenderer6343.client.renderer.WorldSceneRenderer;
 import blockrenderer6343.client.utils.BRUtil;
+import blockrenderer6343.client.utils.ConstructableData;
 import blockrenderer6343.client.utils.EnumColor;
 import blockrenderer6343.integration.nei.GuiMultiblockHandler;
 import blockrenderer6343.integration.nei.StructureHacks;
@@ -41,6 +42,7 @@ import gregtech.api.interfaces.tileentity.ITurnable;
 import gregtech.api.threads.RunnableMachineUpdate;
 import gregtech.api.util.GTStructureUtility;
 import gregtech.api.util.HatchElementBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -95,6 +97,12 @@ public class GTGuiMultiblockHandler extends GuiMultiblockHandler {
         super.initGui();
         addButtonInRow("H").setTooltip(I18n.format("blockrenderer6343.nei.hatch_highlight"))
                 .setClickAction(() -> highlightHatch = !highlightHatch);
+    }
+
+    @Override
+    public void loadMultiblock(IConstructable multiblock, ItemStack stackForm, @NotNull ConstructableData data) {
+        super.loadMultiblock(multiblock, stackForm, data);
+        setChannelTier(GTStructureChannels.HATCH.get(), 1);
     }
 
     @Override

--- a/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
@@ -30,7 +30,6 @@ import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import blockrenderer6343.api.utils.CreativeItemSource;
 import blockrenderer6343.client.renderer.WorldSceneRenderer;
 import blockrenderer6343.client.utils.BRUtil;
-import blockrenderer6343.client.utils.ConstructableData;
 import blockrenderer6343.client.utils.EnumColor;
 import blockrenderer6343.integration.nei.GuiMultiblockHandler;
 import blockrenderer6343.integration.nei.StructureHacks;
@@ -100,17 +99,12 @@ public class GTGuiMultiblockHandler extends GuiMultiblockHandler {
     }
 
     @Override
-    public void loadMultiblock(IConstructable multiblock, ItemStack stackForm, @NotNull ConstructableData data) {
-        super.loadMultiblock(multiblock, stackForm, data);
-        setChannelTier(GTStructureChannels.HATCH.get(), 1);
-    }
-
-    @Override
     protected void loadNewMultiblock() {
         hintForDot.clear();
         dotForPos.clear();
         hatchGroupPositions.clear();
         super.loadNewMultiblock();
+        setChannelTier(GTStructureChannels.HATCH.get(), 1);
         findHints();
     }
 

--- a/src/main/java/blockrenderer6343/integration/nei/GuiMultiblockHandler.java
+++ b/src/main/java/blockrenderer6343/integration/nei/GuiMultiblockHandler.java
@@ -233,7 +233,7 @@ public abstract class GuiMultiblockHandler {
         initializeSceneRenderer(false);
     }
 
-    private void setChannelTier(String channel, int tier) {
+    protected void setChannelTier(String channel, int tier) {
         setChannelTier(channel, tier, true);
     }
 


### PR DESCRIPTION
depbump to accomodate for the PR that caused this issue

sets the channel tier after the multiblock is loaded.
does fix the issue. native solution to https://github.com/GTNewHorizons/GT5-Unofficial/pull/5776

fallout from https://github.com/GTNewHorizons/GT5-Unofficial/pull/5699 (no_hatch channel inversion)