### PR TITLE
Fixed a bug with preview display in NEI

### DIFF
--- a/src/main/java/blockrenderer6343/api/utils/CreativeItemSource.java
+++ b/src/main/java/blockrenderer6343/api/utils/CreativeItemSource.java
@@ -18,6 +18,7 @@ public class CreativeItemSource implements IItemSource {
     public static final CreativeItemSource instance = new CreativeItemSource();
 
     private Reference2ReferenceLinkedOpenHashMap<ItemStack, ItemStack> itemList;
+    private final Reference2ReferenceLinkedOpenHashMap<ItemStack, ItemStack> tempItemList = new Reference2ReferenceLinkedOpenHashMap<>();
 
     @NotNull
     @Override
@@ -33,13 +34,25 @@ public class CreativeItemSource implements IItemSource {
             }
         }
 
+        if (!tempItemList.isEmpty()) {
+            for (var p : tempItemList.reference2ReferenceEntrySet()) {
+                ItemStack itemStack = p.getValue();
+
+                if (predicate.test(itemStack)) {
+                    store.put(itemStack, Integer.MAX_VALUE);
+
+                    return store;
+                }
+            }
+        }
+
         for (var p : itemList.reference2ReferenceEntrySet()) {
             ItemStack itemStack = p.getValue();
 
             if (predicate.test(itemStack)) {
                 store.put(itemStack, Integer.MAX_VALUE);
 
-                itemList.putAndMoveToFirst(itemStack, itemStack);
+                tempItemList.put(itemStack, itemStack);
 
                 return store;
             }

--- a/src/main/java/blockrenderer6343/client/utils/BRUtil.java
+++ b/src/main/java/blockrenderer6343/client/utils/BRUtil.java
@@ -142,7 +142,7 @@ public class BRUtil {
     public static List<ItemStack> getIngredients(WorldSceneRenderer renderer) {
         Map<ItemStack, Integer> controllers = new LinkedHashMap<>();
         Map<ItemStack, Integer> hatches = new LinkedHashMap<>();
-        Map<ItemStack, Integer> blockCounts = new LinkedHashMap<>();
+        Map<ItemStack, Integer> blocks = new LinkedHashMap<>();
 
         for (long renderedBlock : renderer.renderedBlocks) {
             int x = CoordinatePacker.unpackX(renderedBlock);
@@ -178,7 +178,7 @@ public class BRUtil {
             } else if (mte instanceof MTEHatch) {
                 addOrMergeToMap(hatches, stack);
             } else {
-                addOrMergeToMap(blockCounts, stack);
+                addOrMergeToMap(blocks, stack);
             }
         }
 
@@ -186,7 +186,7 @@ public class BRUtil {
 
         addMapToResult(hatches, result);
 
-        blockCounts.entrySet().stream().sorted(Map.Entry.comparingByValue()).forEach(entry -> {
+        blocks.entrySet().stream().sorted(Map.Entry.comparingByValue()).forEach(entry -> {
             ItemStack stack = entry.getKey().copy();
             stack.stackSize = entry.getValue();
             result.add(stack);

--- a/src/main/java/blockrenderer6343/client/utils/BRUtil.java
+++ b/src/main/java/blockrenderer6343/client/utils/BRUtil.java
@@ -2,7 +2,10 @@ package blockrenderer6343.client.utils;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -16,6 +19,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.StatCollector;
@@ -46,6 +50,10 @@ import blockrenderer6343.integration.nei.MultiblockHandler;
 import codechicken.lib.math.MathHelper;
 import codechicken.nei.NEIClientUtils;
 import codechicken.nei.recipe.GuiRecipe;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.implementations.MTEHatch;
+import gregtech.api.metatileentity.implementations.MTEMultiBlockBase;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
 public class BRUtil {
@@ -132,33 +140,83 @@ public class BRUtil {
     }
 
     public static List<ItemStack> getIngredients(WorldSceneRenderer renderer) {
-        List<ItemStack> ingredients = new ArrayList<>();
+        Map<ItemStack, Integer> controllers = new LinkedHashMap<>();
+        Map<ItemStack, Integer> hatches = new LinkedHashMap<>();
+        Map<ItemStack, Integer> blockCounts = new LinkedHashMap<>();
+
         for (long renderedBlock : renderer.renderedBlocks) {
             int x = CoordinatePacker.unpackX(renderedBlock);
             int y = CoordinatePacker.unpackY(renderedBlock);
             int z = CoordinatePacker.unpackZ(renderedBlock);
-            Block block = renderer.world.getBlock(x, y, z);
+            World world = renderer.world;
+
+            Block block = world.getBlock(x, y, z);
             if (block.equals(Blocks.air)) continue;
-            int meta = renderer.world.getBlockMetadata(x, y, z);
-            int qty = block.quantityDropped(renderer.world.rand);
-            ArrayList<ItemStack> itemStacks = new ArrayList<>();
+
+            int meta = world.getBlockMetadata(x, y, z);
+            TileEntity te = world.getTileEntity(x, y, z);
+            IMetaTileEntity mte = null;
+
+            if (te instanceof IGregTechTileEntity gregTechTileEntity) {
+                mte = gregTechTileEntity.getMetaTileEntity();
+            }
+
+            ArrayList<ItemStack> drops;
+            int qty = block.quantityDropped(world.rand);
+
             if (qty != 1) {
-                itemStacks.add(new ItemStack(block));
+                drops = new ArrayList<>();
+                drops.add(new ItemStack(block));
             } else {
-                itemStacks = block.getDrops(renderer.world, x, y, z, meta, 0);
+                drops = block.getDrops(world, x, y, z, meta, 0);
             }
-            boolean added = false;
-            for (ItemStack ingredient : ingredients) {
-                if (NEIClientUtils.areStacksSameTypeWithNBT(ingredient, itemStacks.get(0))) {
-                    ingredient.stackSize++;
-                    added = true;
-                    break;
-                }
+
+            ItemStack stack = drops.get(0).copy();
+
+            if (mte instanceof MTEMultiBlockBase) {
+                addOrMergeToMap(controllers, stack);
+            } else if (mte instanceof MTEHatch) {
+                addOrMergeToMap(hatches, stack);
+            } else {
+                addOrMergeToMap(blockCounts, stack);
             }
-            if (!added) ingredients.add(itemStacks.get(0));
         }
 
-        return ingredients;
+        List<ItemStack> result = new ArrayList<>();
+
+        addMapToResult(hatches, result);
+
+        blockCounts.entrySet().stream().sorted(Map.Entry.comparingByValue()).forEach(entry -> {
+            ItemStack stack = entry.getKey().copy();
+            stack.stackSize = entry.getValue();
+            result.add(stack);
+        });
+
+        addMapToResult(controllers, result);
+
+        return result;
+    }
+
+    private static void addOrMergeToMap(Map<ItemStack, Integer> map, ItemStack newStack) {
+        for (ItemStack key : map.keySet()) {
+            if (NEIClientUtils.areStacksSameTypeWithNBT(key, newStack)) {
+                map.merge(key, 1, Integer::sum);
+                return;
+            }
+        }
+        map.put(newStack, 1);
+    }
+
+    private static void addMapToResult(Map<ItemStack, Integer> map, List<ItemStack> result) {
+        map.entrySet().stream()
+                .sorted(
+                        Comparator.comparingInt(Map.Entry<ItemStack, Integer>::getValue)
+                                .thenComparing(e -> e.getKey().getDisplayName()))
+                .forEach(entry -> {
+                    ItemStack stack = entry.getKey().copy();
+                    stack.stackSize = entry.getValue();
+                    result.add(stack);
+                });
     }
 
     public static List<List<ItemStack>> scanCandidates(Object multi, IStructureElement<Object> element,

--- a/src/main/java/blockrenderer6343/client/utils/BRUtil.java
+++ b/src/main/java/blockrenderer6343/client/utils/BRUtil.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -49,7 +49,6 @@ import blockrenderer6343.integration.nei.MultiblockHandler;
 import codechicken.lib.math.MathHelper;
 import codechicken.nei.ItemStackAmount;
 import codechicken.nei.recipe.GuiRecipe;
-import codechicken.nei.recipe.StackInfo;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatch;
@@ -186,27 +185,17 @@ public class BRUtil {
 
         List<ItemStack> result = new ArrayList<>();
 
-        addAmountToResult(hatches, result);
-
-        blocks.entrySet().stream().sorted(Map.Entry.comparingByValue()).forEach(entry -> {
-            ItemStack stack = StackInfo.loadFromNBT(entry.getKey(), entry.getValue().intValue());
-            result.add(stack);
-        });
-
-        addAmountToResult(controllers, result);
+        addItemStacksWithSorting(hatches, result);
+        addItemStacksWithSorting(blocks, result);
+        addItemStacksWithSorting(controllers, result);
 
         return result;
     }
 
-    private static void addAmountToResult(ItemStackAmount amount, List<ItemStack> result) {
-        amount.entrySet().stream()
-                .sorted(Comparator.comparingLong(Map.Entry<NBTTagCompound, Long>::getValue).thenComparing(e -> {
-                    ItemStack stack = StackInfo.loadFromNBT(e.getKey(), 1);
-                    return stack.getDisplayName();
-                })).forEach(entry -> {
-                    ItemStack stack = StackInfo.loadFromNBT(entry.getKey(), entry.getValue().intValue());
-                    result.add(stack);
-                });
+    private static void addItemStacksWithSorting(ItemStackAmount amount, List<ItemStack> result) {
+        amount.values().stream().sorted(
+                Comparator.comparingLong((ItemStack stack) -> stack.stackSize).thenComparing(ItemStack::getDisplayName))
+                .collect(Collectors.toCollection(() -> result));
     }
 
     public static List<List<ItemStack>> scanCandidates(Object multi, IStructureElement<Object> element,

--- a/src/main/java/blockrenderer6343/client/utils/BRUtil.java
+++ b/src/main/java/blockrenderer6343/client/utils/BRUtil.java
@@ -3,7 +3,6 @@ package blockrenderer6343.client.utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,8 +47,9 @@ import blockrenderer6343.client.world.DummyWorld;
 import blockrenderer6343.integration.nei.BRNEIConfig;
 import blockrenderer6343.integration.nei.MultiblockHandler;
 import codechicken.lib.math.MathHelper;
-import codechicken.nei.NEIClientUtils;
+import codechicken.nei.ItemStackAmount;
 import codechicken.nei.recipe.GuiRecipe;
+import codechicken.nei.recipe.StackInfo;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatch;
@@ -140,9 +140,9 @@ public class BRUtil {
     }
 
     public static List<ItemStack> getIngredients(WorldSceneRenderer renderer) {
-        Map<ItemStack, Integer> controllers = new LinkedHashMap<>();
-        Map<ItemStack, Integer> hatches = new LinkedHashMap<>();
-        Map<ItemStack, Integer> blocks = new LinkedHashMap<>();
+        ItemStackAmount controllers = new ItemStackAmount();
+        ItemStackAmount hatches = new ItemStackAmount();
+        ItemStackAmount blocks = new ItemStackAmount();
 
         for (long renderedBlock : renderer.renderedBlocks) {
             int x = CoordinatePacker.unpackX(renderedBlock);
@@ -171,50 +171,40 @@ public class BRUtil {
                 drops = block.getDrops(world, x, y, z, meta, 0);
             }
 
+            if (drops.isEmpty()) continue;
+
             ItemStack stack = drops.get(0).copy();
 
             if (mte instanceof MTEMultiBlockBase) {
-                addOrMergeToMap(controllers, stack);
+                controllers.add(stack);
             } else if (mte instanceof MTEHatch) {
-                addOrMergeToMap(hatches, stack);
+                hatches.add(stack);
             } else {
-                addOrMergeToMap(blocks, stack);
+                blocks.add(stack);
             }
         }
 
         List<ItemStack> result = new ArrayList<>();
 
-        addMapToResult(hatches, result);
+        addAmountToResult(hatches, result);
 
         blocks.entrySet().stream().sorted(Map.Entry.comparingByValue()).forEach(entry -> {
-            ItemStack stack = entry.getKey().copy();
-            stack.stackSize = entry.getValue();
+            ItemStack stack = StackInfo.loadFromNBT(entry.getKey(), entry.getValue().intValue());
             result.add(stack);
         });
 
-        addMapToResult(controllers, result);
+        addAmountToResult(controllers, result);
 
         return result;
     }
 
-    private static void addOrMergeToMap(Map<ItemStack, Integer> map, ItemStack newStack) {
-        for (ItemStack key : map.keySet()) {
-            if (NEIClientUtils.areStacksSameTypeWithNBT(key, newStack)) {
-                map.merge(key, 1, Integer::sum);
-                return;
-            }
-        }
-        map.put(newStack, 1);
-    }
-
-    private static void addMapToResult(Map<ItemStack, Integer> map, List<ItemStack> result) {
-        map.entrySet().stream()
-                .sorted(
-                        Comparator.comparingInt(Map.Entry<ItemStack, Integer>::getValue)
-                                .thenComparing(e -> e.getKey().getDisplayName()))
-                .forEach(entry -> {
-                    ItemStack stack = entry.getKey().copy();
-                    stack.stackSize = entry.getValue();
+    private static void addAmountToResult(ItemStackAmount amount, List<ItemStack> result) {
+        amount.entrySet().stream()
+                .sorted(Comparator.comparingLong(Map.Entry<NBTTagCompound, Long>::getValue).thenComparing(e -> {
+                    ItemStack stack = StackInfo.loadFromNBT(e.getKey(), 1);
+                    return stack.getDisplayName();
+                })).forEach(entry -> {
+                    ItemStack stack = StackInfo.loadFromNBT(entry.getKey(), entry.getValue().intValue());
                     result.add(stack);
                 });
     }


### PR DESCRIPTION
When changing tiers in the preview, hatches will now always be in their correct positions
Added sorting for catalysts:
Controller
All Blocks
Hatches

<img width="78" height="535" alt="image" src="https://github.com/user-attachments/assets/025cdecb-18e1-4eac-acc4-cc73075631e0" />
