### PR TITLE
Make non GT controllers appear first in ingredient list

### DIFF
--- a/src/main/java/blockrenderer6343/client/utils/BRUtil.java
+++ b/src/main/java/blockrenderer6343/client/utils/BRUtil.java
@@ -1,5 +1,7 @@
 package blockrenderer6343.client.utils;
 
+import static blockrenderer6343.integration.nei.GuiMultiblockHandler.MB_PLACE_POS;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -153,12 +155,6 @@ public class BRUtil {
             if (block.equals(Blocks.air)) continue;
 
             int meta = world.getBlockMetadata(x, y, z);
-            TileEntity te = world.getTileEntity(x, y, z);
-            IMetaTileEntity mte = null;
-
-            if (te instanceof IGregTechTileEntity gregTechTileEntity) {
-                mte = gregTechTileEntity.getMetaTileEntity();
-            }
 
             ArrayList<ItemStack> drops;
             int qty = block.quantityDropped(world.rand);
@@ -174,10 +170,25 @@ public class BRUtil {
 
             ItemStack stack = drops.get(0).copy();
 
-            if (mte instanceof MTEMultiBlockBase) {
+            if (BlockRenderer6343.isGTLoaded) {
+                TileEntity te = world.getTileEntity(x, y, z);
+                IMetaTileEntity mte = null;
+
+                if (te instanceof IGregTechTileEntity gregTechTileEntity) {
+                    mte = gregTechTileEntity.getMetaTileEntity();
+                }
+
+                if (mte instanceof MTEMultiBlockBase) {
+                    controllers.add(stack);
+                    continue;
+                } else if (mte instanceof MTEHatch) {
+                    hatches.add(stack);
+                    continue;
+                }
+            }
+
+            if (x == MB_PLACE_POS.x && y == MB_PLACE_POS.y && z == MB_PLACE_POS.z) {
                 controllers.add(stack);
-            } else if (mte instanceof MTEHatch) {
-                hatches.add(stack);
             } else {
                 blocks.add(stack);
             }

--- a/src/main/java/blockrenderer6343/integration/nei/GuiMultiblockHandler.java
+++ b/src/main/java/blockrenderer6343/integration/nei/GuiMultiblockHandler.java
@@ -77,7 +77,7 @@ public abstract class GuiMultiblockHandler {
     protected static final int SLIDER_WIDTH = BUTTON_RIGHT - BETWEEN_BUTTON_X - 2;
     protected static final float DEFAULT_RANGE_MULTIPLIER = 3.5f;
     protected static final int MAX_PLACE_ROUNDS = 2000;
-    protected static final BlockPos MB_PLACE_POS = new BlockPos(0, 64, 0);
+    public static final BlockPos MB_PLACE_POS = new BlockPos(0, 64, 0);
     protected static final BlockPos SELECTED_BLOCK = new BlockPos().set(NO_SELECTED_BLOCK);
     protected static final ItemStack DEFAULT_TRIGGER = new ItemStack(StructureLibAPI.getDefaultHologramItem());
 


### PR DESCRIPTION
Makes the main block in non GT multis or the "controller" appear first in the ingredient list.
<img width="46" height="237" alt="Screenshot_20260424_170111" src="https://github.com/user-attachments/assets/1c973650-6b6b-4e0b-a88e-0fe4b194402f" />

Kinda what https://github.com/GTNewHorizons/BlockRenderer6343/pull/45 introduced, but for non gt multis.

Also removes the GT hard dep that https://github.com/GTNewHorizons/BlockRenderer6343/pull/45 introduced.