### PR TITLE
Raise Max Tier Check Limit

### DIFF
--- a/src/main/java/blockrenderer6343/integration/nei/StructureHacks.java
+++ b/src/main/java/blockrenderer6343/integration/nei/StructureHacks.java
@@ -32,7 +32,7 @@ import it.unimi.dsi.fastutil.objects.ObjectSet;
 @SuppressWarnings({ "unchecked" })
 public class StructureHacks {
 
-    private static final int MAX_TIERS_TO_CHECK = 50;
+    private static final int MAX_TIERS_TO_CHECK = 100;
     private static final List<String> TIERED_ELEMENTS = new ArrayList<>();
     private static final String CHANNEL_ELEMENT, ON_ELEMENT_PASS, TRIGGER_ITEM_TRANSFORM;
     public static final String LAZY_ELEMENT = "com.gtnewhorizon.structurelib.structure.LazyStructureElement";


### PR DESCRIPTION
## Summary
Raises the limit.

Glass now went above 50, causing them to no longer appear in the nei slider. This raises the limit so it does.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
