### PR TITLE
fix STRUCTURE_LENGTH and STRUCTURE_HEIGHT not being respected by "Tier" Slider in NEI

### DIFF
--- a/src/main/java/blockrenderer6343/integration/gregtech/GTConstructableScan.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GTConstructableScan.java
@@ -86,8 +86,7 @@ public class GTConstructableScan implements Runnable {
             }
 
             if (data.hasData()) {
-                int estimatedTier = world.estimateTierFromConstructable(
-                        e -> {}, multi);
+                int estimatedTier = world.estimateTierFromConstructable(e -> {}, multi);
                 if (estimatedTier > 1) {
                     data.setMaxTier(estimatedTier, "");
                 }

--- a/src/main/java/blockrenderer6343/integration/gregtech/GTConstructableScan.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GTConstructableScan.java
@@ -60,6 +60,7 @@ public class GTConstructableScan implements Runnable {
         ObjectSet<IConstructable> secondScan = new ObjectOpenHashSet<>();
         Object2ObjectMap<IConstructable, ConstructableData> constructableData = new Object2ObjectOpenHashMap<>();
         ConstructableData data = new ConstructableData();
+        ObserverWorld world = new ObserverWorld();
 
         for (Pair<IConstructable, Collection<IStructureElement<IConstructable>[]>> pair : constructables) {
             IConstructable multi = pair.left();
@@ -85,6 +86,11 @@ public class GTConstructableScan implements Runnable {
             }
 
             if (data.hasData()) {
+                int estimatedTier = world.estimateTierFromConstructable(
+                        e -> {}, multi);
+                if (estimatedTier > 1) {
+                    data.setMaxTier(estimatedTier, "");
+                }
                 constructableData.put(multi, data);
                 data = new ConstructableData();
             } else if (structures.size() > 1) {
@@ -92,7 +98,6 @@ public class GTConstructableScan implements Runnable {
             }
         }
 
-        ObserverWorld world = new ObserverWorld();
         for (IConstructable multi : secondScan) {
             int tier = world.estimateTierFromConstructable(
                     stack -> result.computeIfAbsent(BRUtil.hashStack(stack), k -> new ObjectOpenHashSet<>()).add(multi),


### PR DESCRIPTION
## Summary
fixes an issue, where the max length or height of a multi wasnt respected by the Tier slider in NEI. a few examples before vs after:
Before:
AAL: caps at 15 slices
<img width="397" height="522" alt="image" src="https://github.com/user-attachments/assets/32ac5246-60ff-4f4e-a220-2a0053a27f9b" />

LSC: caps at height 11
<img width="405" height="571" alt="image" src="https://github.com/user-attachments/assets/6e1d798d-7e6d-40b8-bd16-83d4ac407265" />

Substation: caps at height 6
<img width="410" height="540" alt="image" src="https://github.com/user-attachments/assets/131b3a8e-3114-4c68-8210-a8d53642ffca" />

After:
AAL: correctly caps at 16 slices:
<img width="409" height="563" alt="image" src="https://github.com/user-attachments/assets/d280f6b7-b970-48c1-b37d-46fc02684f88" />

LSC: caps at height 50, which is its max set codewise:
<img width="417" height="590" alt="image" src="https://github.com/user-attachments/assets/8a2441d4-aa31-4672-b29a-bf710ff934fe" />

Substation: caps at height 18, also defined in code:
<img width="419" height="582" alt="image" src="https://github.com/user-attachments/assets/a79f19a9-493d-473e-a243-1f18bd7536e6" />

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26117
## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
