### PR TITLE
Fix GT hatch highlight positions not updating correctly

### DIFF
--- a/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
+++ b/src/main/java/blockrenderer6343/integration/gregtech/GTGuiMultiblockHandler.java
@@ -101,8 +101,6 @@ public class GTGuiMultiblockHandler extends GuiMultiblockHandler {
     @Override
     protected void loadNewMultiblock() {
         hintForDot.clear();
-        dotForPos.clear();
-        hatchGroupPositions.clear();
         super.loadNewMultiblock();
         setChannelTier(GTStructureChannels.HATCH.get(), 1);
         findHints();
@@ -154,6 +152,9 @@ public class GTGuiMultiblockHandler extends GuiMultiblockHandler {
 
     @Override
     protected void placeMultiblock() {
+        dotForPos.clear();
+        hatchGroupPositions.clear();
+
         if (RunnableMachineUpdate.isCurrentThreadEnabled()) {
             RunnableMachineUpdate.setCurrentThreadEnabled(false);
         }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Changes cached hatch positions to be cleared every time the tier of the multi is changed instead of only on first placement.

Before
<img width="322" height="267" alt="image" src="https://github.com/user-attachments/assets/b18de043-da9d-4ff4-955a-ff76bd0a1e10" />
After
<img width="330" height="317" alt="emm_hatches" src="https://github.com/user-attachments/assets/dab42993-d211-414f-a5e0-421a73c94d46" />
(both pictures are from the same tier)



## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
